### PR TITLE
Add role friendly name for galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@
 dependencies: []
 
 galaxy_info:
+  role_name: nfs
   author: 'Maciej Delmanowski'
   description: 'Configure NFS4 client'
   company: 'DebOps'


### PR DESCRIPTION
I've no permissions to devoinc/ansible-nfs