### PR TITLE
update when condition for restart tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
   service:
     name: '{{ nfs_utils_daemon }}'
     state: 'restarted'
-  when: nfs__register_config|changed and
+  when: nfs__register_config.changed and
         ansible_distribution == 'Debian' and
         ansible_distribution_release in [ 'wheezy', 'jessie' ]
 
@@ -35,7 +35,7 @@
   service:
     name: '{{ nfs_utils_daemon }}'
     state: 'restarted'
-  when: nfs__register_config|changed and
+  when: nfs__register_config.changed and
         ansible_os_family == 'RedHat'
 
 - name: Manage NFS mount points


### PR DESCRIPTION
"|" seems deprecated and needs to be replaced with "."